### PR TITLE
feat: localize ui and refine prompt workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_ARK_API_KEY=
+VITE_ARK_BASE=https://ark.ap-southeast.bytepluses.com/api/v3
+VITE_CHATGPT_API_KEY=
+VITE_CHATGPT_BASE=https://api.openai.example/v1

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended', 'plugin:react/jsx-runtime', 'prettier'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {
+    'react/prop-types': 'off',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,55 @@
-Webchon - Seedream 4.0 editor
+# Seedream 4.0 Studio
+
+React + Vite 기반의 Seedream 4.0 이미지 생성/편집 스튜디오입니다. Text to Image, Image to Image 두 모드를 지원하며 BytePlus ModelArk Seedream 4.0과 ChatGPT 기반 프롬프트 강화를 연동할 수 있도록 설계되었습니다.
+
+## 주요 기능
+
+- **탭 네비게이션**: Text to Image / Image to Image 를 전환하면서 URL `?tab=` 파라미터와 동기화합니다.
+- **프롬프트 박스**: 원본/강화 프롬프트를 비교·편집하며 ChatGPT API를 통한 강화 버튼을 제공합니다.
+- **비율/해상도 선택**: 정의된 Aspect Ratio & Resolution Preset 조합으로 출력 크기를 계산합니다.
+- **Seedream 4.0 호출**: fetch + AbortController + 지수 백오프 재시도로 안정적인 호출을 수행하도록 구성했습니다.
+- **Image to Image 업로드**: JPEG/PNG, 10MB 이하, 1:3~3:1 비율 검사, 최대 8개의 참조 이미지 순서 변경 기능을 제공합니다.
+- **히스토리 드로어**: LocalStorage(`seedream.history.v1`)에 최근 100건을 저장하고 재로딩/삭제/링크 열기를 지원합니다.
+- **접근성**: 모달/드로어 포커스 트랩, 키보드 네비게이션, 포커스 스타일 등을 제공합니다.
+- **라이트/다크 테마**: 헤더에서 테마를 즉시 전환하며, CSS 변수 기반의 색상 시스템을 사용합니다.
+
+## 환경 변수
+
+`.env.example` 파일을 참고해 `.env.local` 등에 환경 변수를 정의하세요. Vite는 `VITE_` prefix가 있는 값만 노출됩니다.
+
+```
+VITE_ARK_API_KEY=YOUR_ARK_KEY
+VITE_ARK_BASE=https://ark.ap-southeast.bytepluses.com/api/v3
+VITE_CHATGPT_API_KEY=YOUR_OPENAI_KEY
+VITE_CHATGPT_BASE=https://api.openai.example/v1
+```
+
+## 실행 방법
+
+```bash
+npm install
+npm run dev
+```
+
+> **주의:** 샌드박스 환경에서는 npm 레지스트리 접근이 제한될 수 있습니다. 이 경우 로컬 개발 환경에서 의존성을 설치한 뒤 실행하세요.
+
+## 테마 색상 커스터마이징
+
+`src/theme/color.ts` 파일에서 Primary 컬러와 라이트/다크 테마 팔레트를 정의합니다. 필요 시 해당 파일의 값을 수정해 브랜드 컬러를 적용하고, 앱을 재빌드하면 전체 UI에 반영됩니다.
+
+## 빌드
+
+```bash
+npm run build
+```
+
+## 테스트 체크리스트
+
+- [ ] 프롬프트 강화 결과 반영 및 수정 가능 여부
+- [ ] 비율/해상도 조합 해상도 계산 검증
+- [ ] Image to Image 업로드 제약 확인
+- [ ] 동일 조건 재생성 시 중복 호출 방지
+- [ ] 히스토리 저장/복원/삭제/재생성 동작 확인
+- [ ] 키보드 내비게이션 및 포커스 이동 검증
+- [ ] 에러 메시지 및 취소 동작 확인
+- [ ] 워터마크/스트리밍/시퀀스 옵션 적용 확인

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Seedream 4.0 Studio</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "seedream-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext .ts,.tsx"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.379.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2",
+    "date-fns": "^3.6.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.34.1",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,139 @@
+import { useEffect } from 'react';
+import { TextToImagePanel } from './components/TextToImagePanel';
+import { ImageToImagePanel } from './components/ImageToImagePanel';
+import { useAppStore } from './store/appStore';
+import type { EditorTab, HistoryItem } from './types/history';
+import { HistoryDrawer } from './features/history/HistoryDrawer';
+import { applyTheme } from './theme/color';
+
+const tabs: { id: EditorTab; label: string; description: string }[] = [
+  { id: 't2i', label: '텍스트 → 이미지', description: '프롬프트만으로 Seedream 4.0 이미지를 생성합니다.' },
+  { id: 'i2i', label: '이미지 → 이미지', description: '기존 이미지를 업로드하고 프롬프트로 변주합니다.' },
+];
+
+export default function App() {
+  const {
+    activeTab,
+    setActiveTab,
+    historyOpen,
+    toggleHistory,
+    setHistoryOpen,
+    setPendingHistory,
+    theme,
+    setTheme,
+    toggleTheme,
+  } = useAppStore();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const tab = params.get('tab');
+    if (tab === 't2i' || tab === 'i2i') {
+      setActiveTab(tab);
+    }
+  }, [setActiveTab]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const storedTheme = window.localStorage.getItem('seedream.theme');
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      setTheme(storedTheme);
+      return;
+    }
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setTheme(prefersDark ? 'dark' : 'light');
+  }, [setTheme]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      return;
+    }
+    applyTheme(theme);
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.setAttribute('data-theme', theme);
+    window.localStorage.setItem('seedream.theme', theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set('tab', activeTab);
+    const query = params.toString();
+    const url = `${window.location.pathname}?${query}`;
+    window.history.replaceState({}, '', url);
+  }, [activeTab]);
+
+  const handleSelectHistory = (item: HistoryItem) => {
+    setHistoryOpen(false);
+    setActiveTab(item.source);
+    setPendingHistory(item);
+  };
+
+  return (
+    <div className="min-h-screen bg-background text-text transition-colors">
+      <header className="border-b border-border bg-surface/80 backdrop-blur transition-colors">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold">Seedream 4.0 스튜디오</h1>
+            <p className="text-xs text-muted">텍스트와 이미지를 조합해 Seedream 4.0 결과물을 빠르게 시도해 보세요.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="rounded-md border border-border px-3 py-1 text-sm transition hover:bg-surface/70"
+              aria-label={`${theme === 'dark' ? '라이트' : '다크'} 모드로 전환`}
+            >
+              {theme === 'dark' ? '🌞 라이트 모드' : '🌙 다크 모드'}
+            </button>
+            <button
+              type="button"
+              onClick={toggleHistory}
+              className="rounded-md border border-border px-3 py-1 text-sm transition hover:bg-surface/70"
+            >
+              히스토리
+            </button>
+            <a
+              href="https://www.byteplus.com/en/modelark"
+              target="_blank"
+              rel="noreferrer"
+              className="rounded-md bg-primary px-3 py-1 text-sm font-medium text-primary-foreground transition hover:bg-primary/80"
+            >
+              ModelArk 문서
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 pb-12">
+        <nav className="mt-8 flex flex-wrap items-center gap-3" aria-label="주요 탭">
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={`rounded-lg border px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                  isActive
+                    ? 'border-primary bg-primary/10 text-primary shadow'
+                    : 'border-border bg-surface/60 text-muted hover:border-primary/60 hover:text-primary'
+                }`}
+                aria-pressed={isActive}
+              >
+                <div className="font-semibold">{tab.label}</div>
+                <div className="text-xs text-muted">{tab.description}</div>
+              </button>
+            );
+          })}
+        </nav>
+
+        <section className="mt-8">
+          {activeTab === 't2i' ? <TextToImagePanel /> : <ImageToImagePanel />}
+        </section>
+      </main>
+
+      <HistoryDrawer open={historyOpen} onClose={() => setHistoryOpen(false)} onSelect={handleSelectHistory} />
+    </div>
+  );
+}

--- a/src/components/AspectSelector.tsx
+++ b/src/components/AspectSelector.tsx
@@ -1,0 +1,33 @@
+import { ASPECT_RATIO_OPTIONS, type AspectRatio } from '../types/history';
+
+interface AspectSelectorProps {
+  value: AspectRatio;
+  onChange: (aspect: AspectRatio) => void;
+}
+
+export function AspectSelector({ value, onChange }: AspectSelectorProps) {
+  return (
+    <div>
+      <label className="mb-2 block text-sm font-medium text-muted">화면 비율</label>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+        {ASPECT_RATIO_OPTIONS.map((option) => {
+          const isActive = option === value;
+          return (
+            <button
+              key={option}
+              type="button"
+              className={`rounded-md border px-3 py-2 text-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                isActive
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-surface/70 text-text hover:border-primary/60 hover:text-primary'
+              }`}
+              onClick={() => onChange(option)}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ImageToImagePanel.tsx
+++ b/src/components/ImageToImagePanel.tsx
@@ -1,0 +1,467 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AspectSelector } from './AspectSelector';
+import { ResolutionSelector } from './ResolutionSelector';
+import { PromptBox } from './PromptBox';
+import { PreviewGrid } from './PreviewGrid';
+import { computeDimensions } from '../lib/imageSizing';
+import { enhancePrompt, requestSeedreamImages, type SeedreamImageToImageRequest } from '../lib/api';
+import { prepareImageAsset } from '../lib/images';
+import { createId } from '../lib/id';
+import type { ImageAsset, ImageValidationError } from '../types/images';
+import { useHistoryStore } from '../features/history/historyStore';
+import { useAppStore } from '../store/appStore';
+import type { AspectRatio, HistoryItem, HistoryParams, ResolutionPreset } from '../types/history';
+
+const REFERENCE_LIMIT = 8;
+
+export function ImageToImagePanel() {
+  const addHistory = useHistoryStore((state) => state.addItem);
+  const { pendingHistory, setPendingHistory } = useAppStore((state) => ({
+    pendingHistory: state.pendingHistory,
+    setPendingHistory: state.setPendingHistory,
+  }));
+
+  const [sourceImage, setSourceImage] = useState<ImageAsset | null>(null);
+  const [referenceImages, setReferenceImages] = useState<ImageAsset[]>([]);
+  const [rawPrompt, setRawPrompt] = useState('');
+  const [enhancedPrompt, setEnhancedPrompt] = useState('');
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
+  const [resolution, setResolution] = useState<ResolutionPreset>('720p');
+  const [seed, setSeed] = useState<number | undefined>();
+  const [steps, setSteps] = useState<number>(30);
+  const [guidance, setGuidance] = useState<number>(7);
+  const [watermark, setWatermark] = useState(true);
+  const [stream, setStream] = useState(false);
+  const [sequential, setSequential] = useState<'disabled' | 'enabled'>('disabled');
+
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [images, setImages] = useState<{ url: string; size: string }[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | undefined>();
+  const [enhancing, setEnhancing] = useState(false);
+  const [enhancementError, setEnhancementError] = useState<string | undefined>();
+  const [lastRequest, setLastRequest] = useState<SeedreamImageToImageRequest | null>(null);
+
+  const generateControllerRef = useRef<AbortController | null>(null);
+  const enhanceControllerRef = useRef<AbortController | null>(null);
+  const uploadErrorTimeout = useRef<number | null>(null);
+
+  const dimensions = useMemo(() => computeDimensions(aspectRatio, resolution), [aspectRatio, resolution]);
+
+  useEffect(() => {
+    if (!pendingHistory || pendingHistory.source !== 'i2i') {
+      return;
+    }
+    setRawPrompt(pendingHistory.promptRaw);
+    setEnhancedPrompt(pendingHistory.promptEnhanced ?? '');
+    setAspectRatio(pendingHistory.params.aspectRatio);
+    setResolution(pendingHistory.params.resolution);
+    setSeed(pendingHistory.params.seed);
+    setSteps(pendingHistory.params.steps ?? 30);
+    setGuidance(pendingHistory.params.guidance ?? 7);
+    setWatermark(pendingHistory.params.watermark);
+    setStream(pendingHistory.params.stream);
+    setSequential(pendingHistory.params.sequentialImageGeneration);
+    setImages([]);
+    setSourceImage(null);
+    setReferenceImages([]);
+    setLastRequest(null);
+    setPendingHistory(null);
+  }, [pendingHistory, setPendingHistory]);
+
+  useEffect(() => () => generateControllerRef.current?.abort(), []);
+  useEffect(() => () => enhanceControllerRef.current?.abort(), []);
+
+  const handleEnhance = useCallback(async () => {
+    if (!rawPrompt.trim()) {
+      return;
+    }
+    enhanceControllerRef.current?.abort();
+    const controller = new AbortController();
+    enhanceControllerRef.current = controller;
+    setEnhancing(true);
+    setEnhancementError(undefined);
+    try {
+      const result = await enhancePrompt({ prompt: rawPrompt, mode: 'i2i' }, controller.signal);
+      setEnhancedPrompt(result.enhanced);
+    } catch (error) {
+      if ((error as DOMException).name === 'AbortError') {
+        return;
+      }
+      setEnhancementError((error as Error).message ?? '프롬프트 강화에 실패했습니다.');
+    } finally {
+      setEnhancing(false);
+    }
+  }, [rawPrompt]);
+
+  const handleFileError = (error: ImageValidationError | Error) => {
+    setUploadError(error.message);
+    if (uploadErrorTimeout.current) {
+      window.clearTimeout(uploadErrorTimeout.current);
+    }
+    uploadErrorTimeout.current = window.setTimeout(() => setUploadError(null), 4000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (uploadErrorTimeout.current) {
+        window.clearTimeout(uploadErrorTimeout.current);
+      }
+    };
+  }, []);
+
+  const handleSourceChange = useCallback(async (fileList: FileList | null) => {
+    if (!fileList?.length) {
+      return;
+    }
+    const file = fileList[0];
+    try {
+      const asset = await prepareImageAsset(file);
+      setSourceImage(asset);
+      setUploadError(null);
+    } catch (error) {
+      handleFileError(error as ImageValidationError | Error);
+    }
+  }, []);
+
+  const handleReferenceChange = useCallback(
+    async (fileList: FileList | null) => {
+      if (!fileList?.length) {
+        return;
+      }
+      const current = [...referenceImages];
+      const availableSlots = REFERENCE_LIMIT - current.length;
+      const files = Array.from(fileList).slice(0, availableSlots);
+      const newAssets: ImageAsset[] = [];
+      for (const file of files) {
+        try {
+          const asset = await prepareImageAsset(file);
+          newAssets.push(asset);
+        } catch (error) {
+          handleFileError(error as ImageValidationError | Error);
+          break;
+        }
+      }
+      setReferenceImages([...current, ...newAssets]);
+    },
+    [referenceImages],
+  );
+
+  const removeReference = (id: string) => {
+    setReferenceImages((images) => images.filter((item) => item.id !== id));
+  };
+
+  const moveReference = (id: string, direction: -1 | 1) => {
+    setReferenceImages((images) => {
+      const index = images.findIndex((item) => item.id === id);
+      if (index < 0) {
+        return images;
+      }
+      const newIndex = index + direction;
+      if (newIndex < 0 || newIndex >= images.length) {
+        return images;
+      }
+      const updated = [...images];
+      const [item] = updated.splice(index, 1);
+      updated.splice(newIndex, 0, item);
+      return updated;
+    });
+  };
+
+  const runGeneration = useCallback(
+    async (payload: SeedreamImageToImageRequest) => {
+      generateControllerRef.current?.abort();
+      const controller = new AbortController();
+      generateControllerRef.current = controller;
+      setIsGenerating(true);
+      setGenerateError(undefined);
+      try {
+        const response = await requestSeedreamImages(payload, controller.signal);
+        setImages(response.data);
+        setLastRequest(payload);
+        const historyParams: HistoryParams = {
+          aspectRatio,
+          resolution,
+          width: payload.width ?? dimensions.width,
+          height: payload.height ?? dimensions.height,
+          seed: payload.seed,
+          steps: payload.steps,
+          guidance: payload.guidance_scale,
+          watermark: payload.watermark ?? true,
+          stream: payload.stream ?? false,
+          sequentialImageGeneration: payload.sequential_image_generation ?? 'disabled',
+        };
+        const historyItem: HistoryItem = {
+          id: createId(),
+          createdAt: Date.now(),
+          source: 'i2i',
+          promptRaw: rawPrompt,
+          promptEnhanced: enhancedPrompt || undefined,
+          params: historyParams,
+          thumb: response.data[0]?.url,
+          url: response.data[0]?.url,
+        };
+        addHistory(historyItem);
+      } catch (error) {
+        if ((error as DOMException).name === 'AbortError') {
+          return;
+        }
+        setGenerateError((error as Error).message ?? '이미지 생성에 실패했습니다.');
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [addHistory, aspectRatio, dimensions.height, dimensions.width, enhancedPrompt, rawPrompt, resolution],
+  );
+
+  const handleGenerate = useCallback(() => {
+    const prompt = (enhancedPrompt || rawPrompt).trim();
+    if (!prompt) {
+      setGenerateError('프롬프트를 입력해주세요.');
+      return;
+    }
+    if (!sourceImage) {
+      setGenerateError('원본 이미지를 업로드해주세요.');
+      return;
+    }
+    const payload: SeedreamImageToImageRequest = {
+      prompt,
+      width: dimensions.width,
+      height: dimensions.height,
+      stream,
+      watermark,
+      sequential_image_generation: sequential,
+      seed,
+      steps,
+      guidance_scale: guidance,
+      image: sourceImage.dataUrl,
+      references: referenceImages.map((item) => item.dataUrl),
+    };
+    void runGeneration(payload);
+  }, [dimensions.height, dimensions.width, enhancedPrompt, guidance, rawPrompt, referenceImages, runGeneration, seed, sequential, sourceImage, steps, stream, watermark]);
+
+  const handleRegenerate = useCallback(() => {
+    if (lastRequest) {
+      void runGeneration(lastRequest);
+    } else {
+      handleGenerate();
+    }
+  }, [handleGenerate, lastRequest, runGeneration]);
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+      <div className="space-y-6">
+        <PromptBox
+          mode="i2i"
+          rawPrompt={rawPrompt}
+          enhancedPrompt={enhancedPrompt}
+          onRawChange={setRawPrompt}
+          onEnhancedChange={setEnhancedPrompt}
+          onEnhance={handleEnhance}
+          enhancing={enhancing}
+          enhancementError={enhancementError}
+        />
+
+        <section className="space-y-5 rounded-xl border border-border bg-surface/80 p-4 transition-colors">
+          <div>
+            <h3 className="text-sm font-semibold text-text">원본 이미지</h3>
+            <p className="text-xs text-muted">JPEG 또는 PNG, 최대 10MB. 가로:세로 비율은 1:3~3:1 범위를 권장합니다.</p>
+            <div className="mt-2 rounded-lg border border-dashed border-border p-4">
+              {sourceImage ? (
+                <div className="space-y-2 text-sm">
+                  <img src={sourceImage.dataUrl} alt="원본 이미지" className="max-h-48 w-full rounded-md object-contain" />
+                  <div className="flex items-center justify-between text-xs text-muted">
+                    <span>{sourceImage.name}</span>
+                    <span>
+                      {(sourceImage.size / 1024).toFixed(0)} KB · {sourceImage.width}×{sourceImage.height}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    className="rounded-md border border-border px-3 py-1 text-xs transition hover:bg-surface/70"
+                    onClick={() => setSourceImage(null)}
+                  >
+                    이미지 교체
+                  </button>
+                </div>
+              ) : (
+                <label className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border border-border p-6 text-center text-sm text-muted transition hover:border-primary/70">
+                  <span>이미지 선택</span>
+                  <input
+                    type="file"
+                    accept="image/png,image/jpeg"
+                    className="hidden"
+                    onChange={(event) => {
+                      void handleSourceChange(event.target.files);
+                      if (event.target) {
+                        event.target.value = '';
+                      }
+                    }}
+                  />
+                </label>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-sm font-semibold text-text">레퍼런스 이미지 (선택)</h3>
+            <p className="text-xs text-muted">스타일 가이드를 위해 최대 {REFERENCE_LIMIT}장까지 업로드할 수 있습니다.</p>
+            <div className="mt-2 space-y-3">
+              <label className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border p-4 text-center text-sm text-muted transition hover:border-primary/70">
+                <span>레퍼런스 이미지 추가</span>
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg"
+                  multiple
+                  className="hidden"
+                  onChange={(event) => {
+                    void handleReferenceChange(event.target.files);
+                    if (event.target) {
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              {referenceImages.length > 0 && (
+                <ul className="grid gap-3 sm:grid-cols-2">
+                  {referenceImages.map((item, index) => (
+                    <li key={item.id} className="rounded-lg border border-border bg-background p-2 transition-colors">
+                      <img src={item.dataUrl} alt={`레퍼런스 ${index + 1}`} className="h-32 w-full rounded-md object-cover" />
+                      <div className="mt-2 flex items-center justify-between text-xs text-muted">
+                        <span>{item.width}×{item.height}</span>
+                        <span>{(item.size / 1024).toFixed(0)} KB</span>
+                      </div>
+                      <div className="mt-2 flex items-center justify-between text-xs">
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            className="rounded border border-border px-2 py-1 text-muted transition hover:bg-surface/70 hover:text-text"
+                            onClick={() => moveReference(item.id, -1)}
+                            disabled={index === 0}
+                          >
+                            위로
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded border border-border px-2 py-1 text-muted transition hover:bg-surface/70 hover:text-text"
+                            onClick={() => moveReference(item.id, 1)}
+                            disabled={index === referenceImages.length - 1}
+                          >
+                            아래로
+                          </button>
+                        </div>
+                        <button
+                          type="button"
+                          className="rounded border border-border px-2 py-1 text-red-500 transition hover:bg-surface/70 hover:text-red-400"
+                          onClick={() => removeReference(item.id)}
+                        >
+                          삭제
+                        </button>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          {uploadError && <p className="text-sm text-red-600 dark:text-red-400">{uploadError}</p>}
+        </section>
+
+        <section className="space-y-5 rounded-xl border border-border bg-surface/80 p-4 transition-colors">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <AspectSelector value={aspectRatio} onChange={setAspectRatio} />
+            <ResolutionSelector value={resolution} onChange={setResolution} />
+          </div>
+          <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted">
+            <span className="font-medium text-text">예상 해상도</span>
+            <p className="mt-1">출력 결과는 약 {dimensions.width} × {dimensions.height} 픽셀로 생성됩니다.</p>
+          </div>
+          <fieldset className="space-y-3 rounded-lg border border-border p-3">
+            <legend className="px-2 text-sm font-semibold">고급 파라미터</legend>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="flex flex-col gap-1 text-sm">
+                시드
+                <input
+                  type="number"
+                  value={seed ?? ''}
+                  onChange={(event) => setSeed(event.target.value ? Number(event.target.value) : undefined)}
+                  className="rounded-md border border-border bg-background p-2"
+                  placeholder="무작위"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                스텝
+                <input
+                  type="number"
+                  value={steps}
+                  min={10}
+                  max={150}
+                  onChange={(event) => setSteps(Number(event.target.value))}
+                  className="rounded-md border border-border bg-background p-2"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                가이던스
+                <input
+                  type="number"
+                  value={guidance}
+                  min={1}
+                  max={20}
+                  step={0.5}
+                  onChange={(event) => setGuidance(Number(event.target.value))}
+                  className="rounded-md border border-border bg-background p-2"
+                />
+              </label>
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2 rounded-lg border border-border p-3 text-sm">
+            <legend className="px-2 text-sm font-semibold">생성 옵션</legend>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={watermark}
+                onChange={(event) => setWatermark(event.target.checked)}
+                className="h-4 w-4"
+              />
+              워터마크 추가
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={stream} onChange={(event) => setStream(event.target.checked)} className="h-4 w-4" />
+              스트리밍(베타)
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={sequential === 'enabled'}
+                onChange={(event) => setSequential(event.target.checked ? 'enabled' : 'disabled')}
+                className="h-4 w-4"
+              />
+              연속 이미지 생성 활성화
+            </label>
+          </fieldset>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleGenerate}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/80 disabled:cursor-not-allowed disabled:bg-muted/40"
+              disabled={isGenerating}
+            >
+              {isGenerating ? '생성 중…' : '이미지 변주 생성하기'}
+            </button>
+            {generateError && <span className="text-sm text-red-600 dark:text-red-400">{generateError}</span>}
+          </div>
+        </section>
+      </div>
+
+      <PreviewGrid
+        images={images}
+        loading={isGenerating}
+        error={generateError}
+        onRegenerate={handleRegenerate}
+        className="mt-0"
+      />
+    </div>
+  );
+}

--- a/src/components/PreviewGrid.tsx
+++ b/src/components/PreviewGrid.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from 'react';
+import type { GeneratedImage } from '../types/history';
+
+interface PreviewGridProps {
+  images: GeneratedImage[];
+  loading: boolean;
+  error?: string;
+  onRegenerate?: () => void;
+  className?: string;
+}
+
+export function PreviewGrid({ images, loading, error, onRegenerate, className = 'mt-6' }: PreviewGridProps) {
+  const [selected, setSelected] = useState<GeneratedImage | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (selected) {
+      const closeButton = closeButtonRef.current;
+      const previous = document.activeElement as HTMLElement | null;
+      closeButton?.focus();
+      const onKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          setSelected(null);
+        }
+      };
+      document.addEventListener('keydown', onKeyDown);
+      return () => {
+        document.removeEventListener('keydown', onKeyDown);
+        previous?.focus?.();
+      };
+    }
+    return undefined;
+  }, [selected]);
+
+  return (
+    <section className={`rounded-xl border border-border bg-surface/80 p-4 transition-colors ${className}`}>
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-semibold">결과 미리보기</h2>
+        {onRegenerate && (
+          <button
+            type="button"
+            className="rounded-md border border-border px-3 py-1 text-sm transition hover:bg-surface/70 disabled:cursor-not-allowed disabled:opacity-70"
+            onClick={onRegenerate}
+            disabled={loading}
+          >
+            동일 조건 재생성
+          </button>
+        )}
+      </div>
+
+      {error && <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+      {loading ? (
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-48 animate-pulse rounded-lg bg-muted/30" />
+          ))}
+        </div>
+      ) : images.length === 0 ? (
+        <p className="mt-4 text-sm text-muted">아직 생성된 이미지가 없습니다. 왼쪽에서 설정을 선택하고 이미지를 만들어보세요.</p>
+      ) : (
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {images.map((image, index) => (
+            <button
+              key={`${image.url}-${index}`}
+              type="button"
+              className="group relative overflow-hidden rounded-lg border border-border transition hover:border-primary/60"
+              onClick={() => setSelected(image)}
+            >
+              <img src={image.url} alt="생성된 이미지" className="h-48 w-full object-cover transition group-hover:scale-105" />
+              <div className="absolute bottom-0 left-0 right-0 bg-black/60 p-2 text-xs text-primary-foreground">
+                {image.size}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {selected && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6">
+          <div className="relative w-full max-w-4xl">
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="absolute right-4 top-4 rounded-md border border-border bg-surface/80 px-3 py-1 text-sm transition hover:bg-surface"
+              onClick={() => setSelected(null)}
+            >
+              닫기
+            </button>
+            <img src={selected.url} alt="미리보기" className="max-h-[70vh] w-full rounded-lg object-contain" />
+            <div className="mt-3 flex items-center justify-between text-sm text-muted">
+              <span>{selected.size}</span>
+              <a
+                href={selected.url}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-md border border-border px-3 py-1 transition hover:bg-surface"
+              >
+                새 탭에서 열기
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/PromptBox.tsx
+++ b/src/components/PromptBox.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react';
+
+interface PromptBoxProps {
+  mode: 't2i' | 'i2i';
+  rawPrompt: string;
+  enhancedPrompt: string;
+  onRawChange: (value: string) => void;
+  onEnhancedChange: (value: string) => void;
+  onEnhance: () => void;
+  enhancing: boolean;
+  enhancementError?: string;
+}
+
+export function PromptBox({
+  mode,
+  rawPrompt,
+  enhancedPrompt,
+  onRawChange,
+  onEnhancedChange,
+  onEnhance,
+  enhancing,
+  enhancementError,
+}: PromptBoxProps) {
+  const [view, setView] = useState<'raw' | 'enhanced'>(enhancedPrompt ? 'enhanced' : 'raw');
+
+  useEffect(() => {
+    if (enhancedPrompt) {
+      setView('enhanced');
+    }
+  }, [enhancedPrompt]);
+
+  return (
+    <section aria-label="프롬프트" className="rounded-xl border border-border bg-surface/80 p-4 transition-colors">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-lg font-semibold">프롬프트</h2>
+          <p className="text-xs text-muted">
+            {mode === 't2i'
+              ? '생성하고 싶은 장면을 자세히 작성한 뒤 Seedream 4.0에 맞춰 강화해 보세요.'
+              : '원본 이미지를 어떻게 바꾸고 싶은지 설명하고 Seedream 4.0에 맞게 다듬을 수 있습니다.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/80 disabled:cursor-not-allowed disabled:bg-muted/40"
+          onClick={onEnhance}
+          disabled={enhancing || !rawPrompt.trim()}
+        >
+          {enhancing ? '강화 중…' : '⚡ Seedream 4.0 프롬프트 강화'}
+        </button>
+      </div>
+
+      <div className="mt-4 flex items-center gap-2 text-sm" role="tablist" aria-label="프롬프트 보기 전환">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'raw'}
+          aria-controls="prompt-raw"
+          className={`rounded-md px-3 py-1 transition ${
+            view === 'raw' ? 'bg-primary/10 text-primary' : 'text-muted hover:text-text'
+          }`}
+          onClick={() => setView('raw')}
+        >
+          원본
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'enhanced'}
+          aria-controls="prompt-enhanced"
+          className={`rounded-md px-3 py-1 transition ${
+            view === 'enhanced' ? 'bg-primary/10 text-primary' : 'text-muted hover:text-text'
+          }`}
+          onClick={() => setView('enhanced')}
+          disabled={!enhancedPrompt}
+        >
+          강화본
+        </button>
+      </div>
+
+      <div className="mt-3 grid gap-4 md:grid-cols-2">
+        <label className="flex flex-col gap-2" id="prompt-raw">
+          <span className="text-sm font-medium text-muted">원본 프롬프트</span>
+          <textarea
+            value={rawPrompt}
+            onChange={(event) => onRawChange(event.target.value)}
+            className={`min-h-[140px] rounded-md border border-border bg-background p-3 text-sm text-text placeholder:text-muted transition ${
+              view === 'raw' ? 'ring-2 ring-primary' : ''
+            }`}
+            placeholder="생성하고 싶은 장면을 자세히 묘사해주세요"
+          />
+        </label>
+        <label className="flex flex-col gap-2" id="prompt-enhanced">
+          <span className="text-sm font-medium text-muted">강화된 프롬프트</span>
+          <textarea
+            value={enhancedPrompt}
+            onChange={(event) => onEnhancedChange(event.target.value)}
+            className={`min-h-[140px] rounded-md border border-border bg-background p-3 text-sm text-text placeholder:text-muted transition ${
+              view === 'enhanced' ? 'ring-2 ring-primary' : ''
+            }`}
+            placeholder="프롬프트 강화 결과가 여기에 표시됩니다"
+          />
+        </label>
+      </div>
+
+      <div className="mt-3 rounded-md border border-border bg-surface/70 p-3 text-sm text-muted transition-colors">
+        <p className="font-medium text-text">현재 강조: {view === 'raw' ? '원본 프롬프트' : '강화된 프롬프트'}</p>
+        <p className="mt-1 text-xs text-muted">상단 탭에서 두 버전을 전환하며 비교해 보세요. 생성 시에는 강화된 프롬프트가 사용되지만 자유롭게 수정할 수 있습니다.</p>
+      </div>
+
+      {enhancementError && (
+        <p className="mt-2 text-sm text-red-600 dark:text-red-400">{enhancementError}</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/ResolutionSelector.tsx
+++ b/src/components/ResolutionSelector.tsx
@@ -1,0 +1,33 @@
+import { RESOLUTION_OPTIONS, type ResolutionPreset } from '../types/history';
+
+interface ResolutionSelectorProps {
+  value: ResolutionPreset;
+  onChange: (resolution: ResolutionPreset) => void;
+}
+
+export function ResolutionSelector({ value, onChange }: ResolutionSelectorProps) {
+  return (
+    <div>
+      <label className="mb-2 block text-sm font-medium text-muted">해상도 프리셋</label>
+      <div className="flex gap-2">
+        {RESOLUTION_OPTIONS.map((option) => {
+          const isActive = option === value;
+          return (
+            <button
+              key={option}
+              type="button"
+              className={`rounded-md border px-4 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ${
+                isActive
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-surface/70 text-text hover:border-primary/60 hover:text-primary'
+              }`}
+              onClick={() => onChange(option)}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/TextToImagePanel.tsx
+++ b/src/components/TextToImagePanel.tsx
@@ -1,0 +1,271 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AspectSelector } from './AspectSelector';
+import { ResolutionSelector } from './ResolutionSelector';
+import { PromptBox } from './PromptBox';
+import { PreviewGrid } from './PreviewGrid';
+import { computeDimensions } from '../lib/imageSizing';
+import { enhancePrompt, requestSeedreamImages, type SeedreamTextToImageRequest } from '../lib/api';
+import { createId } from '../lib/id';
+import { useHistoryStore } from '../features/history/historyStore';
+import { useAppStore } from '../store/appStore';
+import type { AspectRatio, HistoryItem, HistoryParams, ResolutionPreset } from '../types/history';
+
+export function TextToImagePanel() {
+  const addHistory = useHistoryStore((state) => state.addItem);
+  const { pendingHistory, setPendingHistory } = useAppStore((state) => ({
+    pendingHistory: state.pendingHistory,
+    setPendingHistory: state.setPendingHistory,
+  }));
+
+  const [rawPrompt, setRawPrompt] = useState('');
+  const [enhancedPrompt, setEnhancedPrompt] = useState('');
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>('16:9');
+  const [resolution, setResolution] = useState<ResolutionPreset>('720p');
+  const [seed, setSeed] = useState<number | undefined>();
+  const [steps, setSteps] = useState<number>(30);
+  const [guidance, setGuidance] = useState<number>(7);
+  const [watermark, setWatermark] = useState(true);
+  const [stream, setStream] = useState(false);
+  const [sequential, setSequential] = useState<'disabled' | 'enabled'>('disabled');
+
+  const [images, setImages] = useState<{ url: string; size: string }[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [generateError, setGenerateError] = useState<string | undefined>();
+  const [enhancing, setEnhancing] = useState(false);
+  const [enhancementError, setEnhancementError] = useState<string | undefined>();
+  const [lastRequest, setLastRequest] = useState<SeedreamTextToImageRequest | null>(null);
+
+  const generateControllerRef = useRef<AbortController | null>(null);
+  const enhanceControllerRef = useRef<AbortController | null>(null);
+
+  const dimensions = useMemo(() => computeDimensions(aspectRatio, resolution), [aspectRatio, resolution]);
+
+  useEffect(() => {
+    if (!pendingHistory || pendingHistory.source !== 't2i') {
+      return;
+    }
+    setRawPrompt(pendingHistory.promptRaw);
+    setEnhancedPrompt(pendingHistory.promptEnhanced ?? '');
+    setAspectRatio(pendingHistory.params.aspectRatio);
+    setResolution(pendingHistory.params.resolution);
+    setSeed(pendingHistory.params.seed);
+    setSteps(pendingHistory.params.steps ?? 30);
+    setGuidance(pendingHistory.params.guidance ?? 7);
+    setWatermark(pendingHistory.params.watermark);
+    setStream(pendingHistory.params.stream);
+    setSequential(pendingHistory.params.sequentialImageGeneration);
+    setLastRequest(null);
+    setImages([]);
+    setPendingHistory(null);
+  }, [pendingHistory, setPendingHistory]);
+
+  useEffect(() => () => generateControllerRef.current?.abort(), []);
+  useEffect(() => () => enhanceControllerRef.current?.abort(), []);
+
+  const handleEnhance = useCallback(async () => {
+    if (!rawPrompt.trim()) {
+      return;
+    }
+    enhanceControllerRef.current?.abort();
+    const controller = new AbortController();
+    enhanceControllerRef.current = controller;
+    setEnhancing(true);
+    setEnhancementError(undefined);
+    try {
+      const result = await enhancePrompt({ prompt: rawPrompt, mode: 't2i' }, controller.signal);
+      setEnhancedPrompt(result.enhanced);
+    } catch (error) {
+      if ((error as DOMException).name === 'AbortError') {
+        return;
+      }
+      setEnhancementError((error as Error).message ?? '프롬프트 강화에 실패했습니다.');
+    } finally {
+      setEnhancing(false);
+    }
+  }, [rawPrompt]);
+
+  const runGeneration = useCallback(
+    async (payload: SeedreamTextToImageRequest) => {
+      generateControllerRef.current?.abort();
+      const controller = new AbortController();
+      generateControllerRef.current = controller;
+      setIsGenerating(true);
+      setGenerateError(undefined);
+      try {
+        const response = await requestSeedreamImages(payload, controller.signal);
+        setImages(response.data);
+        setLastRequest(payload);
+        const historyParams: HistoryParams = {
+          aspectRatio,
+          resolution,
+          width: payload.width ?? dimensions.width,
+          height: payload.height ?? dimensions.height,
+          seed: payload.seed,
+          steps: payload.steps,
+          guidance: payload.guidance_scale,
+          watermark: payload.watermark ?? true,
+          stream: payload.stream ?? false,
+          sequentialImageGeneration: payload.sequential_image_generation ?? 'disabled',
+        };
+        const historyItem: HistoryItem = {
+          id: createId(),
+          createdAt: Date.now(),
+          source: 't2i',
+          promptRaw: rawPrompt,
+          promptEnhanced: enhancedPrompt || undefined,
+          params: historyParams,
+          thumb: response.data[0]?.url,
+          url: response.data[0]?.url,
+        };
+        addHistory(historyItem);
+      } catch (error) {
+        if ((error as DOMException).name === 'AbortError') {
+          return;
+        }
+        setGenerateError((error as Error).message ?? '이미지 생성에 실패했습니다.');
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [addHistory, aspectRatio, dimensions.height, dimensions.width, enhancedPrompt, rawPrompt, resolution],
+  );
+
+  const handleGenerate = useCallback(() => {
+    const prompt = (enhancedPrompt || rawPrompt).trim();
+    if (!prompt) {
+      setGenerateError('프롬프트를 입력해주세요.');
+      return;
+    }
+    const payload: SeedreamTextToImageRequest = {
+      prompt,
+      width: dimensions.width,
+      height: dimensions.height,
+      stream,
+      watermark,
+      sequential_image_generation: sequential,
+      seed,
+      steps,
+      guidance_scale: guidance,
+    };
+    void runGeneration(payload);
+  }, [dimensions.height, dimensions.width, enhancedPrompt, guidance, rawPrompt, runGeneration, seed, sequential, steps, stream, watermark]);
+
+  const handleRegenerate = useCallback(() => {
+    if (lastRequest) {
+      void runGeneration(lastRequest);
+    } else {
+      handleGenerate();
+    }
+  }, [handleGenerate, lastRequest, runGeneration]);
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.15fr)]">
+      <div className="space-y-6">
+        <PromptBox
+          mode="t2i"
+          rawPrompt={rawPrompt}
+          enhancedPrompt={enhancedPrompt}
+          onRawChange={setRawPrompt}
+          onEnhancedChange={setEnhancedPrompt}
+          onEnhance={handleEnhance}
+          enhancing={enhancing}
+          enhancementError={enhancementError}
+        />
+
+        <section className="space-y-5 rounded-xl border border-border bg-surface/80 p-4 transition-colors">
+          <div className="grid gap-4 lg:grid-cols-2">
+            <AspectSelector value={aspectRatio} onChange={setAspectRatio} />
+            <ResolutionSelector value={resolution} onChange={setResolution} />
+          </div>
+          <div className="rounded-lg border border-dashed border-border p-3 text-sm text-muted">
+            <span className="font-medium text-text">예상 해상도</span>
+            <p className="mt-1">출력 결과는 약 {dimensions.width} × {dimensions.height} 픽셀로 생성됩니다.</p>
+          </div>
+          <fieldset className="space-y-3 rounded-lg border border-border p-3">
+            <legend className="px-2 text-sm font-semibold">고급 파라미터</legend>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <label className="flex flex-col gap-1 text-sm">
+                시드
+                <input
+                  type="number"
+                  value={seed ?? ''}
+                  onChange={(event) => setSeed(event.target.value ? Number(event.target.value) : undefined)}
+                  className="rounded-md border border-border bg-background p-2"
+                  placeholder="무작위"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                스텝
+                <input
+                  type="number"
+                  value={steps}
+                  min={10}
+                  max={150}
+                  onChange={(event) => setSteps(Number(event.target.value))}
+                  className="rounded-md border border-border bg-background p-2"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                가이던스
+                <input
+                  type="number"
+                  value={guidance}
+                  min={1}
+                  max={20}
+                  step={0.5}
+                  onChange={(event) => setGuidance(Number(event.target.value))}
+                  className="rounded-md border border-border bg-background p-2"
+                />
+              </label>
+            </div>
+          </fieldset>
+          <fieldset className="space-y-2 rounded-lg border border-border p-3 text-sm">
+            <legend className="px-2 text-sm font-semibold">생성 옵션</legend>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={watermark}
+                onChange={(event) => setWatermark(event.target.checked)}
+                className="h-4 w-4"
+              />
+              워터마크 추가
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" checked={stream} onChange={(event) => setStream(event.target.checked)} className="h-4 w-4" />
+              스트리밍(베타)
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={sequential === 'enabled'}
+                onChange={(event) => setSequential(event.target.checked ? 'enabled' : 'disabled')}
+                className="h-4 w-4"
+              />
+              연속 이미지 생성 활성화
+            </label>
+          </fieldset>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleGenerate}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-primary/80 disabled:cursor-not-allowed disabled:bg-muted/40"
+              disabled={isGenerating}
+            >
+              {isGenerating ? '생성 중…' : '이미지 생성하기'}
+            </button>
+            {generateError && <span className="text-sm text-red-600 dark:text-red-400">{generateError}</span>}
+          </div>
+        </section>
+      </div>
+
+      <PreviewGrid
+        images={images}
+        loading={isGenerating}
+        error={generateError}
+        onRegenerate={handleRegenerate}
+        className="mt-0"
+      />
+    </div>
+  );
+}

--- a/src/features/history/HistoryDrawer.tsx
+++ b/src/features/history/HistoryDrawer.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { useHistoryStore } from './historyStore';
+import type { HistoryItem } from '../../types/history';
+
+interface HistoryDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (item: HistoryItem) => void;
+}
+
+export function HistoryDrawer({ open, onClose, onSelect }: HistoryDrawerProps) {
+  const { items, removeItem, clear } = useHistoryStore();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const closeButton = closeButtonRef.current;
+    closeButton?.focus();
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      previouslyFocused?.focus?.();
+    };
+  }, [open, onClose]);
+
+  const sorted = useMemo(
+    () => [...items].sort((a, b) => b.createdAt - a.createdAt),
+    [items],
+  );
+
+  return (
+    <div
+      aria-hidden={!open}
+      className={`fixed inset-0 z-40 transition ${open ? 'pointer-events-auto' : 'pointer-events-none'}`}
+    >
+      <div
+        className={`absolute inset-0 bg-black/60 transition-opacity ${open ? 'opacity-100' : 'opacity-0'}`}
+        onClick={onClose}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="히스토리"
+        className={`absolute right-0 top-0 h-full w-full max-w-md transform bg-surface shadow-xl transition-transform duration-300 ${open ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <div className="flex h-full flex-col">
+          <header className="flex items-center justify-between border-b border-border px-6 py-4">
+            <h2 className="text-lg font-semibold">히스토리</h2>
+            <div className="flex items-center gap-2">
+              {sorted.length > 0 && (
+                <button
+                  type="button"
+                  className="rounded-md border border-border px-3 py-1 text-sm transition hover:bg-surface/70"
+                  onClick={clear}
+                >
+                  전체 삭제
+                </button>
+              )}
+              <button
+                ref={closeButtonRef}
+                type="button"
+                className="rounded-md border border-border px-3 py-1 text-sm transition hover:bg-surface/70"
+                onClick={onClose}
+              >
+                닫기
+              </button>
+            </div>
+          </header>
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            {sorted.length === 0 ? (
+              <p className="text-sm text-muted">아직 저장된 히스토리가 없습니다. 이미지를 생성하면 자동으로 기록됩니다.</p>
+            ) : (
+              <ul className="space-y-4">
+                {sorted.map((item) => (
+                  <li key={item.id} className="rounded-lg border border-border bg-background p-4 transition-colors">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs uppercase tracking-wide text-muted">
+                          {item.source === 't2i' ? '텍스트 → 이미지' : '이미지 → 이미지'} · {formatDistanceToNow(item.createdAt, { addSuffix: true, locale: ko })}
+                        </p>
+                        <p className="mt-2 max-h-20 overflow-hidden text-sm text-text">{item.promptEnhanced ?? item.promptRaw}</p>
+                        <p className="mt-2 text-xs text-muted">
+                          {item.params.aspectRatio} · {item.params.resolution} · {item.params.width}×{item.params.height}
+                        </p>
+                      </div>
+                      <button
+                        type="button"
+                        className="text-xs text-muted transition hover:text-red-500"
+                        onClick={() => removeItem(item.id)}
+                        aria-label="히스토리에서 삭제"
+                      >
+                        삭제
+                      </button>
+                    </div>
+                    {item.thumb && (
+                      <img src={item.thumb} alt="히스토리 썸네일" className="mt-3 h-32 w-full rounded-md object-cover" />
+                    )}
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground transition hover:bg-primary/80"
+                        onClick={() => onSelect(item)}
+                      >
+                        설정 불러오기
+                      </button>
+                      {item.url && (
+                        <a
+                          className="rounded-md border border-border px-3 py-1 text-xs transition hover:bg-surface/70"
+                          href={item.url}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          원본 열기
+                        </a>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/features/history/historyStore.ts
+++ b/src/features/history/historyStore.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { HistoryItem } from '../../types/history';
+
+const HISTORY_KEY = 'seedream.history.v1';
+const HISTORY_LIMIT = 100;
+
+interface HistoryState {
+  items: HistoryItem[];
+  addItem: (item: HistoryItem) => void;
+  removeItem: (id: string) => void;
+  clear: () => void;
+}
+
+export const useHistoryStore = create<HistoryState>()(
+  persist(
+    (set, get) => ({
+      items: [],
+      addItem: (item) => {
+        const existing = get().items.filter((i) => i.id !== item.id);
+        const items = [item, ...existing].slice(0, HISTORY_LIMIT);
+        set({ items });
+      },
+      removeItem: (id) => {
+        set({ items: get().items.filter((item) => item.id !== id) });
+      },
+      clear: () => set({ items: [] }),
+    }),
+    {
+      name: HISTORY_KEY,
+      version: 1,
+    },
+  ),
+);

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  --color-primary: 37 99 235;
+  --color-primary-foreground: 248 250 252;
+  --color-background: 248 250 252;
+  --color-surface: 255 255 255;
+  --color-border: 226 232 240;
+  --color-muted: 100 116 139;
+  --color-text: 15 23 42;
+}
+
+.dark {
+  color-scheme: dark;
+  --color-background: 2 8 23;
+  --color-surface: 15 23 42;
+  --color-border: 30 41 59;
+  --color-muted: 148 163 184;
+  --color-text: 226 232 240;
+}
+
+body {
+  @apply min-h-screen bg-background text-text transition-colors;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+a {
+  @apply text-primary underline;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  @apply outline-none ring-2 ring-primary;
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,243 @@
+import type { GeneratedImage } from '../types/history';
+
+export interface SeedreamRequestBase {
+  model?: string;
+  prompt: string;
+  response_format?: 'url' | 'b64_json';
+  stream?: boolean;
+  watermark?: boolean;
+  sequential_image_generation?: 'disabled' | 'enabled';
+  seed?: number;
+  steps?: number;
+  guidance_scale?: number;
+}
+
+export interface SeedreamTextToImageRequest extends SeedreamRequestBase {
+  size?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface SeedreamImageToImageRequest extends SeedreamTextToImageRequest {
+  image: string;
+  references?: string[];
+}
+
+export interface SeedreamResponse {
+  model: string;
+  created: number;
+  data: GeneratedImage[];
+}
+
+export interface PromptEnhancementPayload {
+  prompt: string;
+  mode: 't2i' | 'i2i';
+  maxTokens?: number;
+}
+
+export interface PromptEnhancementResponse {
+  enhanced: string;
+  rationale?: string;
+}
+
+const DEFAULT_MODEL = 'seedream-4-0-250828';
+const DEFAULT_RESPONSE_FORMAT: SeedreamRequestBase['response_format'] = 'url';
+
+const arkBase = import.meta.env.VITE_ARK_BASE;
+const arkApiKey = import.meta.env.VITE_ARK_API_KEY;
+const chatGptBase = import.meta.env.VITE_CHATGPT_BASE;
+const chatGptKey = import.meta.env.VITE_CHATGPT_API_KEY;
+
+if (import.meta.env.DEV) {
+  if (!arkBase) {
+    // eslint-disable-next-line no-console
+    console.warn('VITE_ARK_BASE is not configured. API calls will fail.');
+  }
+  if (!arkApiKey) {
+    // eslint-disable-next-line no-console
+    console.warn('VITE_ARK_API_KEY is not configured. API calls will fail.');
+  }
+  if (!chatGptBase) {
+    // eslint-disable-next-line no-console
+    console.warn('VITE_CHATGPT_BASE is not configured. Prompt enhancement will fail.');
+  }
+  if (!chatGptKey) {
+    // eslint-disable-next-line no-console
+    console.warn('VITE_CHATGPT_API_KEY is not configured. Prompt enhancement will fail.');
+  }
+}
+
+interface RetryOptions {
+  retries?: number;
+  retryDelayMs?: number;
+  backoffFactor?: number;
+}
+
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+async function fetchWithRetry(
+  input: RequestInfo | URL,
+  init: RequestInit & RetryOptions = {},
+): Promise<Response> {
+  const { retries = 2, retryDelayMs = 500, backoffFactor = 2, signal, ...rest } = init;
+
+  let attempt = 0;
+  let lastError: unknown;
+  const controller = new AbortController();
+
+  if (signal) {
+    signal.addEventListener('abort', () => controller.abort(signal.reason), { once: true });
+  }
+
+  while (attempt <= retries) {
+    try {
+      const response = await fetch(input, { ...rest, signal: controller.signal });
+      if (!response.ok && RETRYABLE_STATUS.has(response.status) && attempt < retries) {
+        await delay(retryDelayMs * backoffFactor ** attempt, signal);
+        attempt += 1;
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if ((error as DOMException).name === 'AbortError') {
+        throw error;
+      }
+      lastError = error;
+      if (attempt >= retries) {
+        break;
+      }
+      await delay(retryDelayMs * backoffFactor ** attempt, signal);
+      attempt += 1;
+    }
+  }
+  throw lastError ?? new Error('Request failed');
+}
+
+async function delay(ms: number, signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException('Aborted', 'AbortError');
+  }
+  return new Promise<void>((resolve, reject) => {
+    const id = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(id);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export async function requestSeedreamImages(
+  payload: SeedreamTextToImageRequest | SeedreamImageToImageRequest,
+  signal?: AbortSignal,
+): Promise<SeedreamResponse> {
+  if (!arkBase || !arkApiKey) {
+    throw new Error('Seedream API is not configured.');
+  }
+
+  const body = {
+    model: payload.model ?? DEFAULT_MODEL,
+    prompt: payload.prompt,
+    response_format: payload.response_format ?? DEFAULT_RESPONSE_FORMAT,
+    size: payload.size,
+    width: payload.width,
+    height: payload.height,
+    stream: payload.stream ?? false,
+    watermark: payload.watermark ?? true,
+    sequential_image_generation: payload.sequential_image_generation ?? 'disabled',
+    image: (payload as SeedreamImageToImageRequest).image,
+    images: (payload as SeedreamImageToImageRequest).references,
+    seed: payload.seed,
+    steps: payload.steps,
+    guidance_scale: payload.guidance_scale,
+  };
+
+  const response = await fetchWithRetry(
+    `${arkBase}/images/generations`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${arkApiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response);
+    throw new Error(message);
+  }
+
+  return (await response.json()) as SeedreamResponse;
+}
+
+export async function enhancePrompt(
+  payload: PromptEnhancementPayload,
+  signal?: AbortSignal,
+): Promise<PromptEnhancementResponse> {
+  if (!chatGptBase || !chatGptKey) {
+    throw new Error('ChatGPT API is not configured.');
+  }
+
+  const modeLabel = payload.mode === 't2i' ? 'text-to-image' : 'image-to-image';
+  const body = {
+    model: 'gpt-4o-mini',
+    messages: [
+      {
+        role: 'system',
+        content:
+          '당신은 BytePlus ModelArk의 Seedream 4.0 모델을 위한 시니어 프롬프트 엔지니어입니다. 장면의 주제, 스타일, 구도, 카메라/렌즈, 조명, 분위기, 품질 키워드를 포함해 모델이 선호하는 표현으로 500자 이내의 단일 프롬프트를 작성하세요. 안전 가이드를 준수하고 민감한 내용은 배제하며, 최종 출력만 제공하세요. 기본 응답은 한국어로 작성하되 필요한 핵심 키워드는 영어를 병기할 수 있습니다.',
+      },
+      {
+        role: 'user',
+        content: `작업 모드: ${modeLabel}. 원본 프롬프트:\n${payload.prompt}\n\n위 지침에 따라 Seedream 4.0에 최적화된 프롬프트를 만들어주세요.`,
+      },
+    ],
+    max_output_tokens: payload.maxTokens ?? 400,
+  };
+
+  const response = await fetchWithRetry(
+    `${chatGptBase}/chat/completions`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${chatGptKey}`,
+      },
+      body: JSON.stringify(body),
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    const message = await extractErrorMessage(response);
+    throw new Error(message);
+  }
+
+  const json = await response.json();
+  const content: string = json.choices?.[0]?.message?.content ?? payload.prompt;
+  return {
+    enhanced: content.trim(),
+    rationale: json.choices?.[0]?.message?.refusal ?? undefined,
+  };
+}
+
+async function extractErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data?.error === 'string') {
+      return data.error;
+    }
+    if (data?.error?.message) {
+      return data.error.message;
+    }
+    return JSON.stringify(data);
+  } catch (error) {
+    return `${response.status} ${response.statusText}`;
+  }
+}

--- a/src/lib/id.ts
+++ b/src/lib/id.ts
@@ -1,0 +1,6 @@
+export function createId() {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/src/lib/imageSizing.ts
+++ b/src/lib/imageSizing.ts
@@ -1,0 +1,31 @@
+import type { AspectRatio, ResolutionPreset } from '../types/history';
+
+const RESOLUTION_TO_LONG_SIDE: Record<ResolutionPreset, number> = {
+  '480p': 854,
+  '720p': 1280,
+};
+
+export function parseAspectRatio(aspectRatio: AspectRatio): { width: number; height: number } {
+  const [w, h] = aspectRatio.split(':').map(Number);
+  if (!w || !h) {
+    throw new Error(`Invalid aspect ratio: ${aspectRatio}`);
+  }
+  return { width: w, height: h };
+}
+
+export function computeDimensions(
+  aspectRatio: AspectRatio,
+  resolution: ResolutionPreset,
+): { width: number; height: number } {
+  const { width: ratioW, height: ratioH } = parseAspectRatio(aspectRatio);
+  const longSide = RESOLUTION_TO_LONG_SIDE[resolution];
+  const isLandscape = ratioW >= ratioH;
+  if (isLandscape) {
+    const width = longSide;
+    const height = Math.round((longSide * ratioH) / ratioW);
+    return { width, height };
+  }
+  const height = longSide;
+  const width = Math.round((longSide * ratioW) / ratioH);
+  return { width, height };
+}

--- a/src/lib/images.ts
+++ b/src/lib/images.ts
@@ -1,0 +1,64 @@
+import type { ImageAsset, ImageValidationError } from '../types/images';
+import { createId } from './id';
+
+const SUPPORTED_FORMATS = ['image/jpeg', 'image/png'];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MIN_RATIO = 1 / 3;
+const MAX_RATIO = 3;
+
+export async function prepareImageAsset(file: File): Promise<ImageAsset> {
+  const validationError = await validateImageFile(file);
+  if (validationError) {
+    throw validationError;
+  }
+  const dataUrl = await fileToDataUrl(file);
+  const { width, height } = await readImageSize(dataUrl);
+  return {
+    id: createId(),
+    file,
+    dataUrl,
+    name: file.name,
+    size: file.size,
+    width,
+    height,
+  };
+}
+
+export async function validateImageFile(file: File): Promise<ImageValidationError | null> {
+  if (!SUPPORTED_FORMATS.includes(file.type)) {
+    return { code: 'format', message: 'Only JPEG and PNG files are supported.' };
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return { code: 'size', message: 'Images must be smaller than 10MB.' };
+  }
+  const dataUrl = await fileToDataUrl(file);
+  const { width, height } = await readImageSize(dataUrl);
+  const ratio = width / height;
+  if (ratio < MIN_RATIO || ratio > MAX_RATIO) {
+    return {
+      code: 'ratio',
+      message: 'Image aspect ratio must stay within 1:3 and 3:1.',
+    };
+  }
+  return null;
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function readImageSize(src: string): Promise<{ width: number; height: number }> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      resolve({ width: image.width, height: image.height });
+    };
+    image.onerror = () => reject(new Error('Could not load image.'));
+    image.src = src;
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+import type { HistoryItem } from '../types/history';
+
+export type EditorTab = 't2i' | 'i2i';
+
+export type ThemePreference = 'light' | 'dark';
+
+interface AppState {
+  activeTab: EditorTab;
+  historyOpen: boolean;
+  pendingHistory: HistoryItem | null;
+  theme: ThemePreference;
+  setActiveTab: (tab: EditorTab) => void;
+  toggleHistory: () => void;
+  setHistoryOpen: (open: boolean) => void;
+  setPendingHistory: (item: HistoryItem | null) => void;
+  setTheme: (theme: ThemePreference) => void;
+  toggleTheme: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  activeTab: 't2i',
+  historyOpen: false,
+  pendingHistory: null,
+  theme: 'light',
+  setActiveTab: (tab) => set({ activeTab: tab }),
+  toggleHistory: () => set((state) => ({ historyOpen: !state.historyOpen })),
+  setHistoryOpen: (open) => set({ historyOpen: open }),
+  setPendingHistory: (item) => set({ pendingHistory: item }),
+  setTheme: (theme) => set({ theme }),
+  toggleTheme: () =>
+    set((state) => ({
+      theme: state.theme === 'light' ? 'dark' : 'light',
+    })),
+}));

--- a/src/theme/color.ts
+++ b/src/theme/color.ts
@@ -1,0 +1,68 @@
+export type ThemeName = 'light' | 'dark';
+
+type ThemeColorTokens = {
+  background: string;
+  surface: string;
+  border: string;
+  muted: string;
+  text: string;
+};
+
+const hexToRgbChannels = (hex: string): string => {
+  const normalized = hex.replace('#', '');
+  const value = normalized.length === 3
+    ? normalized
+        .split('')
+        .map((char) => char + char)
+        .join('')
+    : normalized;
+  const numeric = Number.parseInt(value, 16);
+  const r = (numeric >> 16) & 255;
+  const g = (numeric >> 8) & 255;
+  const b = numeric & 255;
+  return `${r} ${g} ${b}`;
+};
+
+const setColorVariable = (name: string, value: string) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.documentElement.style.setProperty(`--color-${name}`, value);
+};
+
+export const PRIMARY_COLORS = {
+  primary: '#2563eb',
+  primaryForeground: '#f8fafc',
+} as const;
+
+export const THEME_COLORS: Record<ThemeName, ThemeColorTokens> = {
+  light: {
+    background: '#f8fafc',
+    surface: '#ffffff',
+    border: '#e2e8f0',
+    muted: '#64748b',
+    text: '#0f172a',
+  },
+  dark: {
+    background: '#020817',
+    surface: '#0f172a',
+    border: '#1e293b',
+    muted: '#94a3b8',
+    text: '#e2e8f0',
+  },
+};
+
+export function applyTheme(theme: ThemeName) {
+  const colors = THEME_COLORS[theme];
+  const entries: Array<[string, string]> = [
+    ['primary', hexToRgbChannels(PRIMARY_COLORS.primary)],
+    ['primary-foreground', hexToRgbChannels(PRIMARY_COLORS.primaryForeground)],
+    ['background', hexToRgbChannels(colors.background)],
+    ['surface', hexToRgbChannels(colors.surface)],
+    ['border', hexToRgbChannels(colors.border)],
+    ['muted', hexToRgbChannels(colors.muted)],
+    ['text', hexToRgbChannels(colors.text)],
+  ];
+
+  entries.forEach(([token, value]) => setColorVariable(token, value));
+}

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -1,0 +1,59 @@
+export type EditorTab = 't2i' | 'i2i';
+
+export interface HistoryParams {
+  aspectRatio: AspectRatio;
+  resolution: ResolutionPreset;
+  width: number;
+  height: number;
+  seed?: number;
+  steps?: number;
+  guidance?: number;
+  watermark: boolean;
+  stream: boolean;
+  sequentialImageGeneration: 'disabled' | 'enabled';
+}
+
+export interface HistoryItem {
+  id: string;
+  createdAt: number;
+  source: EditorTab;
+  promptRaw: string;
+  promptEnhanced?: string;
+  params: HistoryParams;
+  thumb?: string;
+  url?: string;
+}
+
+export type AspectRatio =
+  | '1:1'
+  | '16:9'
+  | '9:16'
+  | '2:3'
+  | '3:4'
+  | '1:2'
+  | '2:1'
+  | '4:5'
+  | '3:2'
+  | '4:3';
+
+export type ResolutionPreset = '480p' | '720p';
+
+export const ASPECT_RATIO_OPTIONS: AspectRatio[] = [
+  '1:1',
+  '16:9',
+  '9:16',
+  '2:3',
+  '3:4',
+  '1:2',
+  '2:1',
+  '4:5',
+  '3:2',
+  '4:3',
+];
+
+export const RESOLUTION_OPTIONS: ResolutionPreset[] = ['480p', '720p'];
+
+export interface GeneratedImage {
+  url: string;
+  size: string;
+}

--- a/src/types/images.ts
+++ b/src/types/images.ts
@@ -1,0 +1,14 @@
+export interface ImageAsset {
+  id: string;
+  file: File;
+  dataUrl: string;
+  name: string;
+  size: number;
+  width?: number;
+  height?: number;
+}
+
+export interface ImageValidationError {
+  code: 'format' | 'size' | 'ratio' | 'count';
+  message: string;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,21 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: 'rgb(var(--color-primary) / <alpha-value>)',
+          foreground: 'rgb(var(--color-primary-foreground) / <alpha-value>)',
+        },
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        surface: 'rgb(var(--color-surface) / <alpha-value>)',
+        border: 'rgb(var(--color-border) / <alpha-value>)',
+        muted: 'rgb(var(--color-muted) / <alpha-value>)',
+        text: 'rgb(var(--color-text) / <alpha-value>)',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- translate the application chrome, history drawer, and shared controls into Korean while keeping the tab navigation intact
- rework both generation panels so the prompt and controls live on the left and the preview lives on the right, with clearer buttons for Seedream 4.0 prompt enhancement
- tune the prompt enhancement request for Seedream 4.0 and refresh preview/history messaging to match the localized experience

## Testing
- npm install *(fails: 403 Forbidden from registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cbca2d37908327809d11f7684b2dad