### PR TITLE
Propagate aspect ratio and remove advanced generation controls

### DIFF
--- a/src/components/ImageToImagePanel.tsx
+++ b/src/components/ImageToImagePanel.tsx
@@ -27,12 +27,6 @@ export function ImageToImagePanel() {
   const [enhancedPrompt, setEnhancedPrompt] = useState('');
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
   const [resolution, setResolution] = useState<ResolutionPreset>('720p');
-  const [seed, setSeed] = useState<number | undefined>();
-  const [steps, setSteps] = useState<number>(30);
-  const [guidance, setGuidance] = useState<number>(7);
-  const [watermark, setWatermark] = useState(true);
-  const [stream, setStream] = useState(false);
-  const [sequential, setSequential] = useState<'disabled' | 'enabled'>('disabled');
 
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [images, setImages] = useState<{ url: string; size: string }[]>([]);
@@ -56,12 +50,6 @@ export function ImageToImagePanel() {
     setEnhancedPrompt(pendingHistory.promptEnhanced ?? '');
     setAspectRatio(pendingHistory.params.aspectRatio);
     setResolution(pendingHistory.params.resolution);
-    setSeed(pendingHistory.params.seed);
-    setSteps(pendingHistory.params.steps ?? 30);
-    setGuidance(pendingHistory.params.guidance ?? 7);
-    setWatermark(pendingHistory.params.watermark);
-    setStream(pendingHistory.params.stream);
-    setSequential(pendingHistory.params.sequentialImageGeneration);
     setImages([]);
     setSourceImage(null);
     setReferenceImages([]);
@@ -184,12 +172,6 @@ export function ImageToImagePanel() {
           resolution,
           width: payload.width ?? dimensions.width,
           height: payload.height ?? dimensions.height,
-          seed: payload.seed,
-          steps: payload.steps,
-          guidance: payload.guidance_scale,
-          watermark: payload.watermark ?? true,
-          stream: payload.stream ?? false,
-          sequentialImageGeneration: payload.sequential_image_generation ?? 'disabled',
         };
         const historyItem: HistoryItem = {
           id: createId(),
@@ -228,17 +210,12 @@ export function ImageToImagePanel() {
       prompt,
       width: dimensions.width,
       height: dimensions.height,
-      stream,
-      watermark,
-      sequential_image_generation: sequential,
-      seed,
-      steps,
-      guidance_scale: guidance,
+      aspect_ratio: aspectRatio,
       image: sourceImage.dataUrl,
       references: referenceImages.map((item) => item.dataUrl),
     };
     void runGeneration(payload);
-  }, [dimensions.height, dimensions.width, enhancedPrompt, guidance, rawPrompt, referenceImages, runGeneration, seed, sequential, sourceImage, steps, stream, watermark]);
+  }, [aspectRatio, dimensions.height, dimensions.width, enhancedPrompt, rawPrompt, referenceImages, runGeneration, sourceImage]);
 
   const handleRegenerate = useCallback(() => {
     if (lastRequest) {
@@ -377,70 +354,6 @@ export function ImageToImagePanel() {
             <span className="font-medium text-text">예상 해상도</span>
             <p className="mt-1">출력 결과는 약 {dimensions.width} × {dimensions.height} 픽셀로 생성됩니다.</p>
           </div>
-          <fieldset className="space-y-3 rounded-lg border border-border p-3">
-            <legend className="px-2 text-sm font-semibold">고급 파라미터</legend>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <label className="flex flex-col gap-1 text-sm">
-                시드
-                <input
-                  type="number"
-                  value={seed ?? ''}
-                  onChange={(event) => setSeed(event.target.value ? Number(event.target.value) : undefined)}
-                  className="rounded-md border border-border bg-background p-2"
-                  placeholder="무작위"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                스텝
-                <input
-                  type="number"
-                  value={steps}
-                  min={10}
-                  max={150}
-                  onChange={(event) => setSteps(Number(event.target.value))}
-                  className="rounded-md border border-border bg-background p-2"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                가이던스
-                <input
-                  type="number"
-                  value={guidance}
-                  min={1}
-                  max={20}
-                  step={0.5}
-                  onChange={(event) => setGuidance(Number(event.target.value))}
-                  className="rounded-md border border-border bg-background p-2"
-                />
-              </label>
-            </div>
-          </fieldset>
-          <fieldset className="space-y-2 rounded-lg border border-border p-3 text-sm">
-            <legend className="px-2 text-sm font-semibold">생성 옵션</legend>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={watermark}
-                onChange={(event) => setWatermark(event.target.checked)}
-                className="h-4 w-4"
-              />
-              워터마크 추가
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="checkbox" checked={stream} onChange={(event) => setStream(event.target.checked)} className="h-4 w-4" />
-              스트리밍(베타)
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={sequential === 'enabled'}
-                onChange={(event) => setSequential(event.target.checked ? 'enabled' : 'disabled')}
-                className="h-4 w-4"
-              />
-              연속 이미지 생성 활성화
-            </label>
-          </fieldset>
-
           <div className="flex flex-wrap items-center gap-3">
             <button
               type="button"

--- a/src/components/TextToImagePanel.tsx
+++ b/src/components/TextToImagePanel.tsx
@@ -21,13 +21,6 @@ export function TextToImagePanel() {
   const [enhancedPrompt, setEnhancedPrompt] = useState('');
   const [aspectRatio, setAspectRatio] = useState<AspectRatio>('16:9');
   const [resolution, setResolution] = useState<ResolutionPreset>('720p');
-  const [seed, setSeed] = useState<number | undefined>();
-  const [steps, setSteps] = useState<number>(30);
-  const [guidance, setGuidance] = useState<number>(7);
-  const [watermark, setWatermark] = useState(true);
-  const [stream, setStream] = useState(false);
-  const [sequential, setSequential] = useState<'disabled' | 'enabled'>('disabled');
-
   const [images, setImages] = useState<{ url: string; size: string }[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const [generateError, setGenerateError] = useState<string | undefined>();
@@ -48,12 +41,6 @@ export function TextToImagePanel() {
     setEnhancedPrompt(pendingHistory.promptEnhanced ?? '');
     setAspectRatio(pendingHistory.params.aspectRatio);
     setResolution(pendingHistory.params.resolution);
-    setSeed(pendingHistory.params.seed);
-    setSteps(pendingHistory.params.steps ?? 30);
-    setGuidance(pendingHistory.params.guidance ?? 7);
-    setWatermark(pendingHistory.params.watermark);
-    setStream(pendingHistory.params.stream);
-    setSequential(pendingHistory.params.sequentialImageGeneration);
     setLastRequest(null);
     setImages([]);
     setPendingHistory(null);
@@ -100,12 +87,6 @@ export function TextToImagePanel() {
           resolution,
           width: payload.width ?? dimensions.width,
           height: payload.height ?? dimensions.height,
-          seed: payload.seed,
-          steps: payload.steps,
-          guidance: payload.guidance_scale,
-          watermark: payload.watermark ?? true,
-          stream: payload.stream ?? false,
-          sequentialImageGeneration: payload.sequential_image_generation ?? 'disabled',
         };
         const historyItem: HistoryItem = {
           id: createId(),
@@ -140,15 +121,10 @@ export function TextToImagePanel() {
       prompt,
       width: dimensions.width,
       height: dimensions.height,
-      stream,
-      watermark,
-      sequential_image_generation: sequential,
-      seed,
-      steps,
-      guidance_scale: guidance,
+      aspect_ratio: aspectRatio,
     };
     void runGeneration(payload);
-  }, [dimensions.height, dimensions.width, enhancedPrompt, guidance, rawPrompt, runGeneration, seed, sequential, steps, stream, watermark]);
+  }, [aspectRatio, dimensions.height, dimensions.width, enhancedPrompt, rawPrompt, runGeneration]);
 
   const handleRegenerate = useCallback(() => {
     if (lastRequest) {
@@ -181,70 +157,6 @@ export function TextToImagePanel() {
             <span className="font-medium text-text">예상 해상도</span>
             <p className="mt-1">출력 결과는 약 {dimensions.width} × {dimensions.height} 픽셀로 생성됩니다.</p>
           </div>
-          <fieldset className="space-y-3 rounded-lg border border-border p-3">
-            <legend className="px-2 text-sm font-semibold">고급 파라미터</legend>
-            <div className="grid gap-3 sm:grid-cols-3">
-              <label className="flex flex-col gap-1 text-sm">
-                시드
-                <input
-                  type="number"
-                  value={seed ?? ''}
-                  onChange={(event) => setSeed(event.target.value ? Number(event.target.value) : undefined)}
-                  className="rounded-md border border-border bg-background p-2"
-                  placeholder="무작위"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                스텝
-                <input
-                  type="number"
-                  value={steps}
-                  min={10}
-                  max={150}
-                  onChange={(event) => setSteps(Number(event.target.value))}
-                  className="rounded-md border border-border bg-background p-2"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                가이던스
-                <input
-                  type="number"
-                  value={guidance}
-                  min={1}
-                  max={20}
-                  step={0.5}
-                  onChange={(event) => setGuidance(Number(event.target.value))}
-                  className="rounded-md border border-border bg-background p-2"
-                />
-              </label>
-            </div>
-          </fieldset>
-          <fieldset className="space-y-2 rounded-lg border border-border p-3 text-sm">
-            <legend className="px-2 text-sm font-semibold">생성 옵션</legend>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={watermark}
-                onChange={(event) => setWatermark(event.target.checked)}
-                className="h-4 w-4"
-              />
-              워터마크 추가
-            </label>
-            <label className="flex items-center gap-2">
-              <input type="checkbox" checked={stream} onChange={(event) => setStream(event.target.checked)} className="h-4 w-4" />
-              스트리밍(베타)
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                checked={sequential === 'enabled'}
-                onChange={(event) => setSequential(event.target.checked ? 'enabled' : 'disabled')}
-                className="h-4 w-4"
-              />
-              연속 이미지 생성 활성화
-            </label>
-          </fieldset>
-
           <div className="flex flex-wrap items-center gap-3">
             <button
               type="button"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { GeneratedImage } from '../types/history';
+import type { AspectRatio, GeneratedImage } from '../types/history';
 
 export interface SeedreamRequestBase {
   model?: string;
@@ -10,6 +10,7 @@ export interface SeedreamRequestBase {
   seed?: number;
   steps?: number;
   guidance_scale?: number;
+  aspect_ratio?: AspectRatio;
 }
 
 export interface SeedreamTextToImageRequest extends SeedreamRequestBase {
@@ -143,6 +144,7 @@ export async function requestSeedreamImages(
     size: payload.size,
     width: payload.width,
     height: payload.height,
+    aspect_ratio: payload.aspect_ratio,
     stream: payload.stream ?? false,
     watermark: payload.watermark ?? true,
     sequential_image_generation: payload.sequential_image_generation ?? 'disabled',

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -5,12 +5,6 @@ export interface HistoryParams {
   resolution: ResolutionPreset;
   width: number;
   height: number;
-  seed?: number;
-  steps?: number;
-  guidance?: number;
-  watermark: boolean;
-  stream: boolean;
-  sequentialImageGeneration: 'disabled' | 'enabled';
 }
 
 export interface HistoryItem {


### PR DESCRIPTION
## Summary
- send the selected aspect ratio through Seedream API payloads so UI choices affect generation
- simplify stored history params to dimension data only
- remove advanced parameter and generation option controls from both editor panels and trim request payloads accordingly

## Testing
- npm run lint *(fails: existing ESLint parser errors across TypeScript files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd020f75588327908e935d3b7fa169