### PR TITLE
Fix Seedream and Nano proxy handlers

### DIFF
--- a/api/generate-seedream.ts
+++ b/api/generate-seedream.ts
@@ -46,8 +46,6 @@ function normalizeForArk(input: AnyBody): AnyBody {
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  console.log('NANO_API_KEY:', process.env.NANO_API_KEY);
-  console.log('ARK_API_KEY:', process.env.ARK_API_KEY);
   if (req.method !== "POST") {
     res.setHeader("Allow", "POST");
     return res.status(405).json({ error: { message: "Method Not Allowed" } });
@@ -71,7 +69,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       apiKey = apiKey.slice(7).trim();
     }
 
-    console.log(`Proxying request for model "${model}" to: ${apiBase}`);
+    console.log(`Proxying request for model "${finalBody.model}" to: ${apiBase}`);
 
     const upstream = await fetch(apiBase, {
       method: 'POST',

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint . --ext .ts,.tsx"
   },
   "dependencies": {
-    "@google/genai": "^1.20.0",
     "@tanstack/react-query": "^5.51.1",
     "@vercel/blob": "^2.0.0",
     "@vercel/node": "^5.3.22",


### PR DESCRIPTION
## Summary
- fix the Seedream proxy log statement so it no longer references an undefined model variable
- rewrite the Nano image proxy to call the Gemini REST endpoint directly and handle image/text responses robustly
- drop the unused @google/genai dependency now that the proxy no longer relies on the SDK

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ab545f348327a85bcc8d3cfef3a2