### PR TITLE
Ensure nano-banana prompts include aspect ratio

### DIFF
--- a/src/components/ImageToImagePanel.tsx
+++ b/src/components/ImageToImagePanel.tsx
@@ -7,6 +7,7 @@ import {
   type SeedreamImageToImageRequest,
 } from "../lib/api";
 import { createId } from "../lib/id";
+import { injectAspectRatioIntoPrompt } from "../lib/modelPrompts";
 import { prepareImageAsset } from "../lib/images";
 import { computeDimensions } from "../lib/imageSizing";
 import { useAppStore } from "../store/appStore";
@@ -306,9 +307,11 @@ export function ImageToImagePanel() {
             .filter(Boolean) as string[]),
         ];
 
+    const finalPrompt = injectAspectRatioIntoPrompt(model, prompt, aspectRatio);
+
     const payload: SeedreamImageToImageRequest = {
       model,
-      prompt,
+      prompt: finalPrompt,
       width: dimensions.width,
       height: dimensions.height,
       aspect_ratio: aspectRatio,

--- a/src/components/TextToImagePanel.tsx
+++ b/src/components/TextToImagePanel.tsx
@@ -9,6 +9,7 @@ import { createId } from '../lib/id';
 import { useHistoryStore } from '../features/history/historyStore';
 import { useAppStore } from '../store/appStore';
 import type { AspectRatio, HistoryItem, HistoryParams, ResolutionPreset } from '../types/history';
+import { injectAspectRatioIntoPrompt } from '../lib/modelPrompts';
 
 export function TextToImagePanel() {
   const addHistory = useHistoryStore((state) => state.addItem);
@@ -118,9 +119,10 @@ export function TextToImagePanel() {
       setGenerateError('프롬프트를 입력해주세요.');
       return;
     }
+    const finalPrompt = injectAspectRatioIntoPrompt(model, prompt, aspectRatio);
     const payload: SeedreamTextToImageRequest = {
       model,
-      prompt,
+      prompt: finalPrompt,
       width: dimensions.width,
       height: dimensions.height,
       aspect_ratio: aspectRatio,

--- a/src/lib/modelPrompts.ts
+++ b/src/lib/modelPrompts.ts
@@ -1,0 +1,33 @@
+import type { AspectRatio } from '../types/history';
+import type { ImageModel } from '../types/images';
+
+export function injectAspectRatioIntoPrompt(
+  model: ImageModel,
+  prompt: string,
+  aspectRatio: AspectRatio,
+): string {
+  if (model !== 'nano-banana') {
+    return prompt;
+  }
+
+  const trimmedPrompt = prompt.trim();
+  if (!trimmedPrompt) {
+    return prompt;
+  }
+
+  const normalizedRatio = aspectRatio.trim();
+  if (!normalizedRatio) {
+    return trimmedPrompt;
+  }
+
+  if (trimmedPrompt.includes(normalizedRatio)) {
+    return trimmedPrompt;
+  }
+
+  const containsHangul = /[\uAC00-\uD7AF]/.test(trimmedPrompt);
+  if (containsHangul) {
+    return `${trimmedPrompt}, ${normalizedRatio} 비율`;
+  }
+
+  return `${trimmedPrompt} with an aspect ratio of ${normalizedRatio}`;
+}


### PR DESCRIPTION
## Summary
- add a helper to inject aspect ratios into prompts when the nano-banana model is used
- apply the helper in both text-to-image and image-to-image flows so the dropdown selection reaches the prompt

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68db7e661c10832793dca6735d50a18a